### PR TITLE
Add double click Right Command keyboard trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ python whisper-dictation.py -m large -k cmd_r+shift -l en
 
 The models are multilingual, and you can specify a two-letter language code (e.g., "no" for Norwegian) with the `-l` or `--language` option. Specifying the language can improve recognition accuracy, especially for smaller model sizes.
 
+#### Replace macOS default dictation trigger key
+You can use this app to replace macOS built-in dictation. Trigger to begin recording with a double click of Right Command key and stop recording with a single click of Right Command key.
+```bash
+python whisper-dictation.py -m large -k_double_cmd -l en
+```
+To use this trigger, go to System Settings -> Keyboard, disable Dictation. If you double click Right Command key on any text field, macOS will ask whether you want to enable Dictation, so select Don't Ask Again.
+
 ## Setting the App as a Startup Item
 To have the app run automatically when your computer starts, follow these steps:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The models are multilingual, and you can specify a two-letter language code (e.g
 #### Replace macOS default dictation trigger key
 You can use this app to replace macOS built-in dictation. Trigger to begin recording with a double click of Right Command key and stop recording with a single click of Right Command key.
 ```bash
-python whisper-dictation.py -m large -k_double_cmd -l en
+python whisper-dictation.py -m large --k_double_cmd -l en
 ```
 To use this trigger, go to System Settings -> Keyboard, disable Dictation. If you double click Right Command key on any text field, macOS will ask whether you want to enable Dictation, so select Don't Ask Again.
 


### PR DESCRIPTION
Add command line argument `--k_double_cmd`, which makes the app start recording with a double click of the Right Command key, and end recording with a single click of the Right Command key.

This can feel more natural to those who had a habit of using macOS default dictation and have muscle memory for the same keyboard command.