### PR TITLE
Fixed numpy 2.0 not compatible with torch requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pynput
 keyboard
 argparse
 rumps
-numpy
+numpy==1.24.6


### PR DESCRIPTION
Found an issue with torch version not compatible with numpy>2.0 versions. 

Based on numpy's release history, numpy 2.0 is released in February 2024. 

This version requirement need to be updated when open AI and pytorch update their dependencies. 